### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -1,4 +1,6 @@
 name: E2E Tests
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/Sijoma/camunda-operator/security/code-scanning/2](https://github.com/Sijoma/camunda-operator/security/code-scanning/2)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will explicitly define the minimal permissions required for the workflow to function. Since the workflow primarily involves reading repository contents and does not perform any write operations, we will set `contents: read`. This ensures that the workflow has only the permissions it needs, reducing the risk of unintended actions.

The `permissions` block will be added immediately after the `name` field at the top of the file.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
