### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,6 @@
 name: Tests
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/Sijoma/camunda-operator/security/code-scanning/1](https://github.com/Sijoma/camunda-operator/security/code-scanning/1)

To fix the issue, we need to add a `permissions` block to the workflow. Since the workflow only requires read access to the repository contents (e.g., for cloning the code), we can set `contents: read` as the minimal permission. This ensures that the `GITHUB_TOKEN` has only the necessary access for the workflow to function correctly.

The `permissions` block should be added at the root level of the workflow file, so it applies to all jobs in the workflow. Alternatively, it can be added specifically to the `test` job if other jobs in the workflow require different permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
